### PR TITLE
(V1.5) Updated Old Links & Added Links For Discipline Letter Templates

### DIFF
--- a/WEB_ROOT/wildcards/sm_psadmin_content.LPS-DR.content.footer.txt
+++ b/WEB_ROOT/wildcards/sm_psadmin_content.LPS-DR.content.footer.txt
@@ -1,23 +1,92 @@
 <!-- create a hidden table with added rows -->
 <div id="LPS-DRCustomhiddentable" style="display: none;">
-<h2 class="toggle expanded" title="Click here to expand or collapse">Incident Resources</h2>
-<div id="incidentResources" class=""><div class="row">
-<p><a target="_blank" href="https://drive.google.com/file/d/13weNUksaVl3ZckHyQ3rJ7AwXL4hyd1Ix/view">Superintendent Directive Regarding Discipline</a></p>
-<p><a target="_blank" href="https://drive.google.com/file/d/13eQtb8ZQSa8QRxe-E0sdxNCJbRDc6vQ-/view">MOU with the Lawrence Police Department</a></p>
-<p><a target="_blank" href="https://drive.google.com/file/d/1u4sUmr2SOqOPy6SGtCyg_WyptTgIX7A7/view">Code of Conduct Handbook</a></p>
-<p><a target="_blank" href="https://docs.google.com/spreadsheets/d/1rrbimFsjyXHgPltcs5OwK623PthzIKMqPEzQwKIr7A4/view">Code of Conduct Mappings</a></p>
-<p><a target="_blank" href="https://docs.google.com/presentation/d/1xH_yR3av6L1n9v7PWLR2Y-79i4CsUVNukKM7JGx8d3A/view">Reporting Incidents in PowerSchool Deck (Information & Instructions)</a></p>
-<p><a target="_blank" href="https://drive.google.com/file/d/1KHFqIz0-i3GSSLLP3tepsyn0PAfJnJqu/preview">Reporting incidents in PowerSchool Training Video</a></p>
-<p><a target="_blank" href="https://drive.google.com/file/d/1MlZxGKdw5MYGgaxEt-mogJei_rs7nCya/preview">Incident Letters Training Video</a></p>
-<p>&nbsp;</p>
-<p></p>
-<p><a target="_blank" href="http://www.doe.mass.edu/infoservices/data/ssdr/">DESE SSDR Information</a></p>
-<p>&nbsp;</p>
-<p></p>
-<p><a target="_blank" href="https://test-webdisp.lawrence.k12.ma.us/admin/Dashboard.aspx">Old Discipline for REFERENCE ONLY</a></p>
-<p><a target="_blank" href="https://docs.google.com/spreadsheets/d/1dpE3PC-9q2FeZO6-8iKvl49geo8rVew7/edit#gid=2075961696">Old Discipline Code Mappings for REFERENCE ONLY</a></p>
-</div>
-</div>
+  <h2 class="toggle expanded" title="Click here to expand or collapse">Incident Resources</h2>
+  <div id="incidentResources" class="">
+    <div class="row">
+      <!-- <p><a target="_blank" href="https://drive.google.com/file/d/13weNUksaVl3ZckHyQ3rJ7AwXL4hyd1Ix/view">Superintendent Directive Regarding Discipline</a></p>  *Now included in the Code of Conduct Book* -->
+      <p><a target="_blank" href="https://drive.google.com/file/d/13eQtb8ZQSa8QRxe-E0sdxNCJbRDc6vQ-/view">MOU with the Lawrence Police Department</a></p>
+      <p><a target="_blank" href="https://drive.google.com/file/d/11rDS7INSUd9efwX4milCtJ9Ym0wFMkpj/view">Code of Conduct Handbook</a></p> <!-- Version: 2021-22 -->
+      <p><a target="_blank" href="https://docs.google.com/spreadsheets/d/1rrbimFsjyXHgPltcs5OwK623PthzIKMqPEzQwKIr7A4/view">Code of Conduct Mappings</a></p>
+      <p><a target="_blank" href="https://docs.google.com/presentation/d/1xH_yR3av6L1n9v7PWLR2Y-79i4CsUVNukKM7JGx8d3A/view">Reporting Incidents in PowerSchool Deck (Information & Instructions)</a></p>
+      <p><a target="_blank" href="https://drive.google.com/file/d/1KHFqIz0-i3GSSLLP3tepsyn0PAfJnJqu/preview">Reporting incidents in PowerSchool Training Video</a></p>
+      
+      <p><a target="_blank" href="https://docs.google.com/document/d/17PUss7Zfxq7qmkR6j273dBAbCLsyquSr-Fsft8d7g9s/view">Discipline Letter Instructions</a></p>
+      <!-- Letter Template collapsable-list -->
+      <p class="toggle expanded" title="Click here to expand or collapse">Incident Letter Templates</p>
+      <div id="letterTemplates" class="">
+        <div class="row">
+          <table class="grid" data-pstablefilter="">
+            <thead>
+              <th>English</th>
+              <th>Spanish</th>
+            </thead>
+            <tbody>
+              <tr>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1vQnFcEAFBlmBakbf_mfT83mn4sMJV7FB/view?usp=sharing">37H ½ Hearing Outcome - expulsion (English)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1KsKcGAvecbVqCR4Htl7PPK-_tgQCKorf/view?usp=sharing">37H ½ Hearing Outcome - expulsion (Spanish)</a></td>
+              </tr>
+              <tr>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1EXFpRAMDKmkL_FSmY5-mgtzbh5OlcPek/view?usp=sharing">37H ½ Hearing Outcome - suspension (English)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1mUlLqlJe_dOImZnu_zLkHGTy19Sb6NpI/view?usp=sharing">37H ½ Hearing Outcome - suspension (Spanish)</a></td>
+              </tr>
+              <tr>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1UJcC2KhsATlmb02j_NVggbyGJWua70Go/view?usp=sharing">37H ½ Notice - expulsion (English)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1TudWraEd1d5_T-5hvrv4gH_sFoKhQYki/view?usp=sharing">37H ½ Notice - expulsion (Spanish)</a></td>
+              </tr>
+              <tr>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1PQwbPP9B1ma8SiAgPTv-Fr0fBJu1LNB0/view?usp=sharing">37H ½ Notice - suspension (English)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1xRLHvObYogfjL-GlNo8Q0H_sqhyAo8uB/view?usp=sharing">37H ½ Notice - suspension (Spanish)</a></td>
+              </tr>
+              <tr>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1RSf6urFCw6e8q_gYFF-awCsttuda7SFC/view?usp=sharing">37H Hearing Notice (English)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1HeJDwCShDScdbtVNvzcVJgMnEl0G_gAz/view?usp=sharing">37H Hearing Notice (Spanish)</a></td>
+              </tr>
+              <tr>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1kMY0u5Fnb_yKbXsEwyK6hdTTQ2E7l5cN/view?usp=sharing">37H Hearing Outcome - Expel (English)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1tTfTnAJRMONr98JAZVSpdoJoTHBlpNpY/view?usp=sharing">37H Hearing Outcome - Expel (Spanish)</a></td>
+              </tr>
+              <tr>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1BKgD-iCERTC5QX8R3QjLe9fKcg6UaNSt/view?usp=sharing">37H Hearing Outcome - Suspend (English)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1_YwpAHQH9Fr9W5gDQun5tfIqCheC6UuD/view?usp=sharing">37H Hearing Outcome - Suspend (Spanish)</a></td>
+              </tr>
+              <tr>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1V1jdyv0RrHyaJSJdK7ldw1Yckf2yjuuR/view?usp=sharing">In School Suspension Letter (English)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1svFeEfSknWh7TCR1G7lBszHSyksKjxAh/view?usp=sharing">In School Suspension Letter (Spanish</a></td>
+              </tr>
+              <tr>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1MEEnHUFwjiEmqJI2iPJk2nF03eZWYv74/view?usp=sharing">Long Term Suspension - Hearing Outcome (English)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1QvTvm3_Si6gXO3onbp2b3UxX-r8I-DRi/view?usp=sharing">Long Term Suspension - Hearing Outcome (Spanish)</a></td>
+              </tr>
+              <tr>
+                <td><a target="_blank" href="https://docs.google.com/document/d/19Frx_GiklGVqmVY5FT6ShKQKi6YIQNrt/view?usp=sharing">Long Term Suspension Notice (English)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1-d0QlDNrGEujjpjpGix6mPd32kjnm819/view?usp=sharing">Long Term Suspension Notice (Spanish)</a></td>
+              </tr>
+              <tr>
+                <td><a target="_blank" href="https://docs.google.com/document/d/10fV1H5JA0vpmgh3ZDGZZW9wfOaYiCL4A/view?usp=sharing">Short Term Suspension - Hearing Outcome (English)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1CgPDIHQEURWyxqxbyDeTILSKs_WVyVri/view?usp=sharing">Short Term Suspension - Hearing Outcome (Spanish)</a></td>
+              </tr>
+              <tr>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1LRvuBzigwFW3nZaLXYfqHiyjfqKEKUY3/view?usp=sharing">Short Term Suspension Notice (English)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1ClEc8Noy_uXHumoOL15eK3DZxt4j5LMB/view?usp=sharing">Short Term Suspension Notice (Spanish)</a></td>
+              </tr>
+              <tr> <!-- Link to G-Drive folder, keeping here just in case -->
+                <td><a target="_blank" href="https://drive.google.com/drive/folders/1qY2RWEjh5Xm0LbShR2DmCpbVXuwGjU2K">Incident Letter Templates (English)</a></td>
+                <td><a target="_blank" href="https://drive.google.com/drive/folders/1XO41n61zIzH-Ducn2nW5HSFdOAuMzo4y">Incident Letter Templates (Spanish)</a></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <p>&nbsp;</p> <!-- Seems like bad formatting, why not use <br>? -->
+      <p></p>
+      <p><a target="_blank" href="http://www.doe.mass.edu/infoservices/data/ssdr/">DESE SSDR Information</a></p>
+      <p>&nbsp;</p>
+      <p></p>
+      <p><a target="_blank" href="https://drive.google.com/file/d/1MlZxGKdw5MYGgaxEt-mogJei_rs7nCya/preview">Incident Letters Training Video - OUTDATED: REFERENCE ONLY</a></p>
+      <p><a target="_blank" href="https://test-webdisp.lawrence.k12.ma.us/admin/Dashboard.aspx">Discipline - OUTDATED: REFERENCE ONLY</a></p>
+      <p><a target="_blank" href="https://docs.google.com/spreadsheets/d/1dpE3PC-9q2FeZO6-8iKvl49geo8rVew7/edit#gid=2075961696">Discipline Code Mappings - OUTDATED: REFERENCE ONLY</a></p>
+    </div>
+  </div>
 </div>
 
 

--- a/WEB_ROOT/wildcards/sm_psadmin_content.LPS-DR.content.footer.txt
+++ b/WEB_ROOT/wildcards/sm_psadmin_content.LPS-DR.content.footer.txt
@@ -2,105 +2,103 @@
   #letterTemplates {
     border-style: none;
   }
-  #templatesTableHeader {
-    background-color: transparent;
-    font-size: 14px;
-    color: rgb(0, 102, 165);
-    border: none;
+  
+  div#incidentResources ul {
+    margin-left: 5px;
   }
-  #templatesRowDiv {
-    width: 50%;
+  div#incidentResources li {
+    list-style-type: none;
+    list-style-position: outside;
   }
 </style>
 <!-- create a hidden table with added rows -->
 <div id="LPS-DRCustomhiddentable" style="display: none;">
-  <h2 class="toggle expanded" title="Click here to expand or collapse">Incident Resources</h2>
+  <h2 class="toggle expanded lpsCollapsibleHeader" title="Click here to expand or collapse">Incident Resources</h2>
   <div id="incidentResources" class="">
     <div class="row">
-      <!-- <p><a target="_blank" href="https://drive.google.com/file/d/13weNUksaVl3ZckHyQ3rJ7AwXL4hyd1Ix/view">Superintendent Directive Regarding Discipline</a></p>  *Now included in the Code of Conduct Book* -->
-      <p><a target="_blank" href="https://drive.google.com/file/d/13eQtb8ZQSa8QRxe-E0sdxNCJbRDc6vQ-/view">MOU with the Lawrence Police Department</a></p>
-      <p><a target="_blank" href="https://drive.google.com/file/d/11rDS7INSUd9efwX4milCtJ9Ym0wFMkpj/view">Code of Conduct Handbook</a></p> <!-- Version: 2021-22 -->
-      <p><a target="_blank" href="https://docs.google.com/spreadsheets/d/1rrbimFsjyXHgPltcs5OwK623PthzIKMqPEzQwKIr7A4/view">Code of Conduct Mappings</a></p>
-      <p><a target="_blank" href="https://docs.google.com/presentation/d/1xH_yR3av6L1n9v7PWLR2Y-79i4CsUVNukKM7JGx8d3A/view">Reporting Incidents in PowerSchool Deck (Information & Instructions)</a></p>
-      <p><a target="_blank" href="https://drive.google.com/file/d/1KHFqIz0-i3GSSLLP3tepsyn0PAfJnJqu/preview">Reporting incidents in PowerSchool Training Video</a></p>
-      <p><a target="_blank" href="https://docs.google.com/document/d/17PUss7Zfxq7qmkR6j273dBAbCLsyquSr-Fsft8d7g9s/view?usp=sharing">Discipline Letter Instructions</a></p>
-      
-      <!--|===============================|Letter Template Collapsible-Table|===============================|-->
-      <h2 id="templatesTableHeader" class="toggle expanded" title="Click here to expand or collapse">Discipline Letter Templates</h2>
-      <div id="letterTemplates" class="">
-        <div id="templatesRowDiv" class="row">
-          <table class="grid">
-            <thead>
-              <th>English</th>
-              <th>Espa&ntilde;ol</th>
-            </thead>
-            <tbody>
-              <tr>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1vQnFcEAFBlmBakbf_mfT83mn4sMJV7FB/view?usp=sharing">37H ½ Hearing Outcome - expulsion (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1KsKcGAvecbVqCR4Htl7PPK-_tgQCKorf/view?usp=sharing">37H ½ Hearing Outcome - expulsion (Espa&ntilde;ol)</a></td>
-              </tr>
-              <tr>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1EXFpRAMDKmkL_FSmY5-mgtzbh5OlcPek/view?usp=sharing">37H ½ Hearing Outcome - suspension (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1mUlLqlJe_dOImZnu_zLkHGTy19Sb6NpI/view?usp=sharing">37H ½ Hearing Outcome - suspension (Espa&ntilde;ol)</a></td>
-              </tr>
-              <tr>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1UJcC2KhsATlmb02j_NVggbyGJWua70Go/view?usp=sharing">37H ½ Notice - expulsion (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1TudWraEd1d5_T-5hvrv4gH_sFoKhQYki/view?usp=sharing">37H ½ Notice - expulsion (Espa&ntilde;ol)</a></td>
-              </tr>
-              <tr>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1PQwbPP9B1ma8SiAgPTv-Fr0fBJu1LNB0/view?usp=sharing">37H ½ Notice - suspension (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1xRLHvObYogfjL-GlNo8Q0H_sqhyAo8uB/view?usp=sharing">37H ½ Notice - suspension (Espa&ntilde;ol)</a></td>
-              </tr>
-              <tr>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1RSf6urFCw6e8q_gYFF-awCsttuda7SFC/view?usp=sharing">37H Hearing Notice (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1HeJDwCShDScdbtVNvzcVJgMnEl0G_gAz/view?usp=sharing">37H Hearing Notice (Espa&ntilde;ol)</a></td>
-              </tr>
-              <tr>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1kMY0u5Fnb_yKbXsEwyK6hdTTQ2E7l5cN/view?usp=sharing">37H Hearing Outcome - Expel (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1tTfTnAJRMONr98JAZVSpdoJoTHBlpNpY/view?usp=sharing">37H Hearing Outcome - Expel (Espa&ntilde;ol)</a></td>
-              </tr>
-              <tr>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1BKgD-iCERTC5QX8R3QjLe9fKcg6UaNSt/view?usp=sharing">37H Hearing Outcome - Suspend (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1_YwpAHQH9Fr9W5gDQun5tfIqCheC6UuD/view?usp=sharing">37H Hearing Outcome - Suspend (Espa&ntilde;ol)</a></td>
-              </tr>
-              <tr>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1V1jdyv0RrHyaJSJdK7ldw1Yckf2yjuuR/view?usp=sharing">In School Suspension Letter (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1svFeEfSknWh7TCR1G7lBszHSyksKjxAh/view?usp=sharing">In School Suspension Letter (Espa&ntilde;ol)</a></td>
-              </tr>
-              <tr>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1MEEnHUFwjiEmqJI2iPJk2nF03eZWYv74/view?usp=sharing">Long Term Suspension - Hearing Outcome (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1QvTvm3_Si6gXO3onbp2b3UxX-r8I-DRi/view?usp=sharing">Long Term Suspension - Hearing Outcome (Espa&ntilde;ol)</a></td>
-              </tr>
-              <tr>
-                <td><a target="_blank" href="https://docs.google.com/document/d/19Frx_GiklGVqmVY5FT6ShKQKi6YIQNrt/view?usp=sharing">Long Term Suspension Notice (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1-d0QlDNrGEujjpjpGix6mPd32kjnm819/view?usp=sharing">Long Term Suspension Notice (Espa&ntilde;ol)</a></td>
-              </tr>
-              <tr>
-                <td><a target="_blank" href="https://docs.google.com/document/d/10fV1H5JA0vpmgh3ZDGZZW9wfOaYiCL4A/view?usp=sharing">Short Term Suspension - Hearing Outcome (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1CgPDIHQEURWyxqxbyDeTILSKs_WVyVri/view?usp=sharing">Short Term Suspension - Hearing Outcome (Espa&ntilde;ol)</a></td>
-              </tr>
-              <tr>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1LRvuBzigwFW3nZaLXYfqHiyjfqKEKUY3/view?usp=sharing">Short Term Suspension Notice (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1ClEc8Noy_uXHumoOL15eK3DZxt4j5LMB/view?usp=sharing">Short Term Suspension Notice (Espa&ntilde;ol)</a></td>
-              </tr>
-              <!--  Links to Google Drive folder, keeping here just in case [ https://drive.google.com/drive/folders/ ]
-              <tr>
-                <td><a target="_blank" href="1qY2RWEjh5Xm0LbShR2DmCpbVXuwGjU2K">All Incident Letter Templates (English)</a></td>
-                <td><a target="_blank" href="1XO41n61zIzH-Ducn2nW5HSFdOAuMzo4y">All Incident Letter Templates (Espa&ntilde;ol)</a></td>
-              </tr>
-              -->
-            </tbody>
-          </table>
-        </div>
-      </div>
-      <p>&nbsp;</p> <!-- Seems like bad formatting, why not use <br>? -->
-      <p></p>
-      <p><a target="_blank" href="http://www.doe.mass.edu/infoservices/data/ssdr/">DESE SSDR Information</a></p>
-      <p>&nbsp;</p>
-      <p></p>
-      <p><a target="_blank" href="https://drive.google.com/file/d/1MlZxGKdw5MYGgaxEt-mogJei_rs7nCya/preview">Incident Letters Training Video - OUTDATED: REFERENCE ONLY</a></p>
-      <p><a target="_blank" href="https://test-webdisp.lawrence.k12.ma.us/admin/Dashboard.aspx">Discipline - OUTDATED: REFERENCE ONLY</a></p>
-      <p><a target="_blank" href="https://docs.google.com/spreadsheets/d/1dpE3PC-9q2FeZO6-8iKvl49geo8rVew7/edit#gid=2075961696">Discipline Code Mappings - OUTDATED: REFERENCE ONLY</a></p>
+      <ul>
+        <!-- <li><a target="_blank" href="https://drive.google.com/file/d/13weNUksaVl3ZckHyQ3rJ7AwXL4hyd1Ix/view">Superintendent Directive Regarding Discipline</a></li>  *Now included in the Code of Conduct Book* -->
+        <li><a target="_blank" href="https://drive.google.com/file/d/13eQtb8ZQSa8QRxe-E0sdxNCJbRDc6vQ-/view">MOU with the Lawrence Police Department</a></li>
+        <li><a target="_blank" href="https://drive.google.com/file/d/11rDS7INSUd9efwX4milCtJ9Ym0wFMkpj/view">Code of Conduct Handbook</a></li> <!-- Version: 2021-22 -->
+        <li><a target="_blank" href="https://docs.google.com/spreadsheets/d/1rrbimFsjyXHgPltcs5OwK623PthzIKMqPEzQwKIr7A4/view">Code of Conduct Mappings</a></li>
+        <li><a target="_blank" href="https://docs.google.com/presentation/d/1xH_yR3av6L1n9v7PWLR2Y-79i4CsUVNukKM7JGx8d3A/view">Reporting Incidents in PowerSchool Deck (Information & Instructions)</a></li>
+        <li><a target="_blank" href="https://drive.google.com/file/d/1KHFqIz0-i3GSSLLP3tepsyn0PAfJnJqu/preview">Reporting incidents in PowerSchool Training Video</a></li>
+        <li><a target="_blank" href="https://docs.google.com/document/d/17PUss7Zfxq7qmkR6j273dBAbCLsyquSr-Fsft8d7g9s/view?usp=sharing">Discipline Letter Instructions</a></li>
+        <br />
+        <li><a target="_blank" href="http://www.doe.mass.edu/infoservices/data/ssdr/">DESE SSDR Information</a></li>
+        <br />
+        <li><a target="_blank" href="https://drive.google.com/file/d/1MlZxGKdw5MYGgaxEt-mogJei_rs7nCya/preview">Incident Letters Training Video - OUTDATED: REFERENCE ONLY</a></li>
+        <li><a target="_blank" href="https://test-webdisp.lawrence.k12.ma.us/admin/Dashboard.aspx">Discipline - OUTDATED: REFERENCE ONLY</a></li>
+        <li><a target="_blank" href="https://docs.google.com/spreadsheets/d/1dpE3PC-9q2FeZO6-8iKvl49geo8rVew7/edit#gid=2075961696">Discipline Code Mappings - OUTDATED: REFERENCE ONLY</a></li>
+      </ul>
+    </div>
+  </div>
+<!--|===============================|Letter Template Collapsible-Table|===============================|-->
+  <h2 id="letterTemplatesHeader" class="toggle expanded lpsCollapsibleHeader" title="Click here to expand or collapse">Incident Letter Templates</h2>
+  <div id="letterTemplates">
+    <div id="letterTemplatesTable" class="row">
+      <table class="grid">
+        <thead>
+          <th>English</th>
+          <th>Espa&ntilde;ol</th>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1vQnFcEAFBlmBakbf_mfT83mn4sMJV7FB/view?usp=sharing">37H ½ Hearing Outcome - Expulsion</a></td>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1KsKcGAvecbVqCR4Htl7PPK-_tgQCKorf/view?usp=sharing">37H ½ Resultado de la Audiencia - Expulsión</a></td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1EXFpRAMDKmkL_FSmY5-mgtzbh5OlcPek/view?usp=sharing">37H ½ Hearing Outcome - Suspension</a></td>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1mUlLqlJe_dOImZnu_zLkHGTy19Sb6NpI/view?usp=sharing">37H ½ Resultado de la Audiencia - Suspensión</a></td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1UJcC2KhsATlmb02j_NVggbyGJWua70Go/view?usp=sharing">37H ½ Notice - Expulsion</a></td>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1TudWraEd1d5_T-5hvrv4gH_sFoKhQYki/view?usp=sharing">37H ½ Aviso - Expulsión</a></td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1PQwbPP9B1ma8SiAgPTv-Fr0fBJu1LNB0/view?usp=sharing">37H ½ Notice - Suspension</a></td>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1xRLHvObYogfjL-GlNo8Q0H_sqhyAo8uB/view?usp=sharing">37H ½ Aviso - Suspensión</a></td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1RSf6urFCw6e8q_gYFF-awCsttuda7SFC/view?usp=sharing">37H Hearing Notice</a></td>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1HeJDwCShDScdbtVNvzcVJgMnEl0G_gAz/view?usp=sharing">37H Aviso de la Audiencia</a></td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1kMY0u5Fnb_yKbXsEwyK6hdTTQ2E7l5cN/view?usp=sharing">37H Hearing Outcome - Expel</a></td>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1tTfTnAJRMONr98JAZVSpdoJoTHBlpNpY/view?usp=sharing">37H Resultado de la Audiencia - Expulsar</a></td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1BKgD-iCERTC5QX8R3QjLe9fKcg6UaNSt/view?usp=sharing">37H Hearing Outcome - Suspend</a></td>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1_YwpAHQH9Fr9W5gDQun5tfIqCheC6UuD/view?usp=sharing">37H Resultado de la Audiencia - Suspender</a></td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1V1jdyv0RrHyaJSJdK7ldw1Yckf2yjuuR/view?usp=sharing">In School Suspension Letter</a></td>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1svFeEfSknWh7TCR1G7lBszHSyksKjxAh/view?usp=sharing">Carta de Suspensión Escolar</a></td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1MEEnHUFwjiEmqJI2iPJk2nF03eZWYv74/view?usp=sharing">Long Term Suspension - Hearing Outcome</a></td>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1QvTvm3_Si6gXO3onbp2b3UxX-r8I-DRi/view?usp=sharing">Suspensión de Largo Plazo  - Resultado de la Audiencia</a></td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://docs.google.com/document/d/19Frx_GiklGVqmVY5FT6ShKQKi6YIQNrt/view?usp=sharing">Long Term Suspension Notice</a></td>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1-d0QlDNrGEujjpjpGix6mPd32kjnm819/view?usp=sharing">Aviso de Suspensión de Largo Plazo</a></td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://docs.google.com/document/d/10fV1H5JA0vpmgh3ZDGZZW9wfOaYiCL4A/view?usp=sharing">Short Term Suspension - Hearing Outcome</a></td>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1CgPDIHQEURWyxqxbyDeTILSKs_WVyVri/view?usp=sharing">Suspensión de Corto Plazo - Resultado de la Audiencia</a></td>
+          </tr>
+          <tr>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1LRvuBzigwFW3nZaLXYfqHiyjfqKEKUY3/view?usp=sharing">Short Term Suspension Notice</a></td>
+            <td><a target="_blank" href="https://docs.google.com/document/d/1ClEc8Noy_uXHumoOL15eK3DZxt4j5LMB/view?usp=sharing">Aviso de Suspensión de Corto Plazo</a></td>
+          </tr>
+          <!--  Links to Google Drive folder, keeping here just in case [ https://drive.google.com/drive/folders/ ]
+          <tr>
+            <td><a target="_blank" href="1qY2RWEjh5Xm0LbShR2DmCpbVXuwGjU2K">All Incident Letter Templates (English)</a></td>
+            <td><a target="_blank" href="1XO41n61zIzH-Ducn2nW5HSFdOAuMzo4y">All Incident Letter Templates (Espa&ntilde;ol)</a></td>
+          </tr>
+          -->
+        </tbody>
+      </table>
     </div>
   </div>
 </div>
@@ -110,21 +108,21 @@
   function AddLPSDispResources() {
     if ( $j("#incidentBody").length > 0 ) 
     {
-      $j("#myForm > div.box-round").prepend($j("div#LPS-DRCustomhiddentable div#incidentResources"));
-      $j("#myForm > div.box-round").prepend($j("div#LPS-DRCustomhiddentable h2"));
+      var $incidentBox = $j('#myForm > div.box-round');
+      var $lpsHeaders = $j('div#LPS-DRCustomhiddentable h2'); /* [(0)"Incident Resources", (1)"Incident Letter Templates"] */
       
-      /* Load resources tab as collapsed */
-      $j('#myForm > div.box-round > h2:first').each(function() {
+      /* Build by stacking on top of "Incident Description" */
+      $incidentBox.prepend( $j("div#LPS-DRCustomhiddentable div#letterTemplates") );
+      $incidentBox.prepend( $lpsHeaders.eq(1) );
+      $incidentBox.prepend( $j("div#LPS-DRCustomhiddentable div#incidentResources") );
+      $incidentBox.prepend( $lpsHeaders.first() );
+
+      /* Load custom tabs as collapsed */
+      $j('#myForm > div.box-round > h2.lpsCollapsibleHeader').each(function() {
         hideCollapseClasses($j(this));
         hideCollapseText($j(this));
         hideCollapseTarget($j(this));
       });
-      
-      /* Load letter templates table as collapsed */
-      var $ttHeader = $j('#templatesTableHeader');
-      hideCollapseClasses($ttHeader);
-      hideCollapseText($ttHeader);
-      hideCollapseTarget($ttHeader);
       
       $j("div#LPS-DRCustomhiddentable").remove();
     }

--- a/WEB_ROOT/wildcards/sm_psadmin_content.LPS-DR.content.footer.txt
+++ b/WEB_ROOT/wildcards/sm_psadmin_content.LPS-DR.content.footer.txt
@@ -1,3 +1,17 @@
+<style>
+  #letterTemplates {
+    border-style: none;
+  }
+  #templatesTableHeader {
+    background-color: transparent;
+    font-size: 14px;
+    color: rgb(0, 102, 165);
+    border: none;
+  }
+  #templatesRowDiv {
+    width: 50%;
+  }
+</style>
 <!-- create a hidden table with added rows -->
 <div id="LPS-DRCustomhiddentable" style="display: none;">
   <h2 class="toggle expanded" title="Click here to expand or collapse">Incident Resources</h2>
@@ -9,70 +23,72 @@
       <p><a target="_blank" href="https://docs.google.com/spreadsheets/d/1rrbimFsjyXHgPltcs5OwK623PthzIKMqPEzQwKIr7A4/view">Code of Conduct Mappings</a></p>
       <p><a target="_blank" href="https://docs.google.com/presentation/d/1xH_yR3av6L1n9v7PWLR2Y-79i4CsUVNukKM7JGx8d3A/view">Reporting Incidents in PowerSchool Deck (Information & Instructions)</a></p>
       <p><a target="_blank" href="https://drive.google.com/file/d/1KHFqIz0-i3GSSLLP3tepsyn0PAfJnJqu/preview">Reporting incidents in PowerSchool Training Video</a></p>
+      <p><a target="_blank" href="https://docs.google.com/document/d/17PUss7Zfxq7qmkR6j273dBAbCLsyquSr-Fsft8d7g9s/view?usp=sharing">Discipline Letter Instructions</a></p>
       
-      <p><a target="_blank" href="https://docs.google.com/document/d/17PUss7Zfxq7qmkR6j273dBAbCLsyquSr-Fsft8d7g9s/view">Discipline Letter Instructions</a></p>
-      <!-- Letter Template collapsable-list -->
-      <p class="toggle expanded" title="Click here to expand or collapse">Incident Letter Templates</p>
+      <!--|===============================|Letter Template Collapsible-Table|===============================|-->
+      <h2 id="templatesTableHeader" class="toggle expanded" title="Click here to expand or collapse">Discipline Letter Templates</h2>
       <div id="letterTemplates" class="">
-        <div class="row">
-          <table class="grid" data-pstablefilter="">
+        <div id="templatesRowDiv" class="row">
+          <table class="grid">
             <thead>
               <th>English</th>
-              <th>Spanish</th>
+              <th>Espa&ntilde;ol</th>
             </thead>
             <tbody>
               <tr>
                 <td><a target="_blank" href="https://docs.google.com/document/d/1vQnFcEAFBlmBakbf_mfT83mn4sMJV7FB/view?usp=sharing">37H ½ Hearing Outcome - expulsion (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1KsKcGAvecbVqCR4Htl7PPK-_tgQCKorf/view?usp=sharing">37H ½ Hearing Outcome - expulsion (Spanish)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1KsKcGAvecbVqCR4Htl7PPK-_tgQCKorf/view?usp=sharing">37H ½ Hearing Outcome - expulsion (Espa&ntilde;ol)</a></td>
               </tr>
               <tr>
                 <td><a target="_blank" href="https://docs.google.com/document/d/1EXFpRAMDKmkL_FSmY5-mgtzbh5OlcPek/view?usp=sharing">37H ½ Hearing Outcome - suspension (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1mUlLqlJe_dOImZnu_zLkHGTy19Sb6NpI/view?usp=sharing">37H ½ Hearing Outcome - suspension (Spanish)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1mUlLqlJe_dOImZnu_zLkHGTy19Sb6NpI/view?usp=sharing">37H ½ Hearing Outcome - suspension (Espa&ntilde;ol)</a></td>
               </tr>
               <tr>
                 <td><a target="_blank" href="https://docs.google.com/document/d/1UJcC2KhsATlmb02j_NVggbyGJWua70Go/view?usp=sharing">37H ½ Notice - expulsion (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1TudWraEd1d5_T-5hvrv4gH_sFoKhQYki/view?usp=sharing">37H ½ Notice - expulsion (Spanish)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1TudWraEd1d5_T-5hvrv4gH_sFoKhQYki/view?usp=sharing">37H ½ Notice - expulsion (Espa&ntilde;ol)</a></td>
               </tr>
               <tr>
                 <td><a target="_blank" href="https://docs.google.com/document/d/1PQwbPP9B1ma8SiAgPTv-Fr0fBJu1LNB0/view?usp=sharing">37H ½ Notice - suspension (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1xRLHvObYogfjL-GlNo8Q0H_sqhyAo8uB/view?usp=sharing">37H ½ Notice - suspension (Spanish)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1xRLHvObYogfjL-GlNo8Q0H_sqhyAo8uB/view?usp=sharing">37H ½ Notice - suspension (Espa&ntilde;ol)</a></td>
               </tr>
               <tr>
                 <td><a target="_blank" href="https://docs.google.com/document/d/1RSf6urFCw6e8q_gYFF-awCsttuda7SFC/view?usp=sharing">37H Hearing Notice (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1HeJDwCShDScdbtVNvzcVJgMnEl0G_gAz/view?usp=sharing">37H Hearing Notice (Spanish)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1HeJDwCShDScdbtVNvzcVJgMnEl0G_gAz/view?usp=sharing">37H Hearing Notice (Espa&ntilde;ol)</a></td>
               </tr>
               <tr>
                 <td><a target="_blank" href="https://docs.google.com/document/d/1kMY0u5Fnb_yKbXsEwyK6hdTTQ2E7l5cN/view?usp=sharing">37H Hearing Outcome - Expel (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1tTfTnAJRMONr98JAZVSpdoJoTHBlpNpY/view?usp=sharing">37H Hearing Outcome - Expel (Spanish)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1tTfTnAJRMONr98JAZVSpdoJoTHBlpNpY/view?usp=sharing">37H Hearing Outcome - Expel (Espa&ntilde;ol)</a></td>
               </tr>
               <tr>
                 <td><a target="_blank" href="https://docs.google.com/document/d/1BKgD-iCERTC5QX8R3QjLe9fKcg6UaNSt/view?usp=sharing">37H Hearing Outcome - Suspend (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1_YwpAHQH9Fr9W5gDQun5tfIqCheC6UuD/view?usp=sharing">37H Hearing Outcome - Suspend (Spanish)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1_YwpAHQH9Fr9W5gDQun5tfIqCheC6UuD/view?usp=sharing">37H Hearing Outcome - Suspend (Espa&ntilde;ol)</a></td>
               </tr>
               <tr>
                 <td><a target="_blank" href="https://docs.google.com/document/d/1V1jdyv0RrHyaJSJdK7ldw1Yckf2yjuuR/view?usp=sharing">In School Suspension Letter (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1svFeEfSknWh7TCR1G7lBszHSyksKjxAh/view?usp=sharing">In School Suspension Letter (Spanish</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1svFeEfSknWh7TCR1G7lBszHSyksKjxAh/view?usp=sharing">In School Suspension Letter (Espa&ntilde;ol)</a></td>
               </tr>
               <tr>
                 <td><a target="_blank" href="https://docs.google.com/document/d/1MEEnHUFwjiEmqJI2iPJk2nF03eZWYv74/view?usp=sharing">Long Term Suspension - Hearing Outcome (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1QvTvm3_Si6gXO3onbp2b3UxX-r8I-DRi/view?usp=sharing">Long Term Suspension - Hearing Outcome (Spanish)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1QvTvm3_Si6gXO3onbp2b3UxX-r8I-DRi/view?usp=sharing">Long Term Suspension - Hearing Outcome (Espa&ntilde;ol)</a></td>
               </tr>
               <tr>
                 <td><a target="_blank" href="https://docs.google.com/document/d/19Frx_GiklGVqmVY5FT6ShKQKi6YIQNrt/view?usp=sharing">Long Term Suspension Notice (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1-d0QlDNrGEujjpjpGix6mPd32kjnm819/view?usp=sharing">Long Term Suspension Notice (Spanish)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1-d0QlDNrGEujjpjpGix6mPd32kjnm819/view?usp=sharing">Long Term Suspension Notice (Espa&ntilde;ol)</a></td>
               </tr>
               <tr>
                 <td><a target="_blank" href="https://docs.google.com/document/d/10fV1H5JA0vpmgh3ZDGZZW9wfOaYiCL4A/view?usp=sharing">Short Term Suspension - Hearing Outcome (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1CgPDIHQEURWyxqxbyDeTILSKs_WVyVri/view?usp=sharing">Short Term Suspension - Hearing Outcome (Spanish)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1CgPDIHQEURWyxqxbyDeTILSKs_WVyVri/view?usp=sharing">Short Term Suspension - Hearing Outcome (Espa&ntilde;ol)</a></td>
               </tr>
               <tr>
                 <td><a target="_blank" href="https://docs.google.com/document/d/1LRvuBzigwFW3nZaLXYfqHiyjfqKEKUY3/view?usp=sharing">Short Term Suspension Notice (English)</a></td>
-                <td><a target="_blank" href="https://docs.google.com/document/d/1ClEc8Noy_uXHumoOL15eK3DZxt4j5LMB/view?usp=sharing">Short Term Suspension Notice (Spanish)</a></td>
+                <td><a target="_blank" href="https://docs.google.com/document/d/1ClEc8Noy_uXHumoOL15eK3DZxt4j5LMB/view?usp=sharing">Short Term Suspension Notice (Espa&ntilde;ol)</a></td>
               </tr>
-              <tr> <!-- Link to G-Drive folder, keeping here just in case -->
-                <td><a target="_blank" href="https://drive.google.com/drive/folders/1qY2RWEjh5Xm0LbShR2DmCpbVXuwGjU2K">Incident Letter Templates (English)</a></td>
-                <td><a target="_blank" href="https://drive.google.com/drive/folders/1XO41n61zIzH-Ducn2nW5HSFdOAuMzo4y">Incident Letter Templates (Spanish)</a></td>
+              <!--  Links to Google Drive folder, keeping here just in case [ https://drive.google.com/drive/folders/ ]
+              <tr>
+                <td><a target="_blank" href="1qY2RWEjh5Xm0LbShR2DmCpbVXuwGjU2K">All Incident Letter Templates (English)</a></td>
+                <td><a target="_blank" href="1XO41n61zIzH-Ducn2nW5HSFdOAuMzo4y">All Incident Letter Templates (Espa&ntilde;ol)</a></td>
               </tr>
+              -->
             </tbody>
           </table>
         </div>
@@ -91,35 +107,42 @@
 
 
 <script type="text/javascript">
-    function AddLPSDispResources() {
+  function AddLPSDispResources() {
+    if ( $j("#incidentBody").length > 0 ) 
+    {
+      $j("#myForm > div.box-round").prepend($j("div#LPS-DRCustomhiddentable div#incidentResources"));
+      $j("#myForm > div.box-round").prepend($j("div#LPS-DRCustomhiddentable h2"));
+      
+      /* Load resources tab as collapsed */
+      $j('#myForm > div.box-round > h2:first').each(function() {
+        hideCollapseClasses($j(this));
+        hideCollapseText($j(this));
+        hideCollapseTarget($j(this));
+      });
+      
+      /* Load letter templates table as collapsed */
+      var $ttHeader = $j('#templatesTableHeader');
+      hideCollapseClasses($ttHeader);
+      hideCollapseText($ttHeader);
+      hideCollapseTarget($ttHeader);
+      
+      $j("div#LPS-DRCustomhiddentable").remove();
+    }
+  };
 
-if ($j("#incidentBody").length >0)
-{   
-   //$j("div#LPS-DRCustomhiddentable:first").remove(); //PS had double includes in older versions
-   $j("#myForm > div.box-round").prepend($j("div#LPS-DRCustomhiddentable div#incidentResources"));
-   $j("#myForm > div.box-round").prepend($j("div#LPS-DRCustomhiddentable h2"));
-   $j('#myForm > div.box-round > h2:first').each(function(){
-      hideCollapseClasses($j(this));
-      hideCollapseText($j(this));
-      hideCollapseTarget($j(this));
-   });
-   $j("div#LPS-DRCustomhiddentable").remove();
-} else {}
-};
+  //debugger;
+  if (!!LPSDRTEST )
+  {
+      //console.log('LPSDRTEST not is null');
+      var LPSDRTEST = 0;
+  } else {
+      //console.log('LPSDRTEST is null');
+      var LPSDRTEST = 1;
+      $j(document).ready(AddLPSDispResources);
+  }
 
-//debugger;
-if (!!LPSDRTEST )
-{
-    //console.log('LPSDRTEST not is null');
-    var LPSDRTEST = 0;
-} else {
-    //console.log('LPSDRTEST is null');
-    var LPSDRTEST = 1;
-    $j(document).ready(AddLPSDispResources);
-}
-
-//if (LPSDRTEST == 1)
-//{
-    //$j(document).ready(AddLPSDispResources);
-//}
+  //if (LPSDRTEST == 1)
+  //{
+      //$j(document).ready(AddLPSDispResources);
+  //}
 </script>

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,9 +4,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation='http://plugin.powerschool.pearson.com plugin.xsd'
         name="LPS Discipline Resources"
-        version="1.3"
+        version="1.4"
         description="add Discipline Resources to incidents">
-    <publisher name="Logan Arias">
-    <contact email="Logan.Arias@lawrence.k12.ma.us"/>
+    <publisher name="Benjamin Houle">
+    <contact email="Benjamin.Houle@lawrence.k12.ma.us"/>
     </publisher>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation='http://plugin.powerschool.pearson.com plugin.xsd'
         name="LPS Discipline Resources"
-        version="1.4"
+        version="1.5"
         description="add Discipline Resources to incidents">
     <publisher name="Logan Arias">
     <contact email="Logan.Arias@lawrence.k12.ma.us"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
         name="LPS Discipline Resources"
         version="1.4"
         description="add Discipline Resources to incidents">
-    <publisher name="Benjamin Houle">
-    <contact email="Benjamin.Houle@lawrence.k12.ma.us"/>
+    <publisher name="Logan Arias">
+    <contact email="Logan.Arias@lawrence.k12.ma.us"/>
     </publisher>
 </plugin>


### PR DESCRIPTION
### CHANGES:
- Added table with links to English & Spanish Versions of Incident Letter Templates.
  - _(V1.5)_ Header for table drop-down is now the more consistent with the size of other list items
  - _(V1.5)_ Table drop-down now starts as collapsed
  - _(V1.5)_ Spanish links are now tagged with _(Español)_ and English links with _(English)_
- Moved old training video link down next to other old reference links.
- Removed Superintendent Directive link as it is now in Code of Conduct Book.